### PR TITLE
Add better flex support for 5+ product series

### DIFF
--- a/web/src/components/homepageSeriesProduct.js
+++ b/web/src/components/homepageSeriesProduct.js
@@ -21,7 +21,8 @@ const HomepageSeriesProduct = ({ product, series }) => {
           series.products.length === 1 ? styles.seriesImageFull : "",
           series.products.length === 2 ? styles.seriesImageHalves : "",
           series.products.length === 3 ? styles.seriesImageThirds : "",
-          series.products.length === 4 ? styles.seriesImageQuarters : ""
+          series.products.length === 4 ? styles.seriesImageQuarters : "",
+          series.products.length > 4 ? styles.seriesImageMany : ""
         )}
         to={`/products/${product.slug.current}`}
         style={{

--- a/web/src/components/homepageSeriesProduct.module.scss
+++ b/web/src/components/homepageSeriesProduct.module.scss
@@ -2,14 +2,11 @@
 
 .seriesImageContainer {
   display: block;
+  flex-grow: 1;
 
   &:last-child {
     margin-right: 0;
     margin-bottom: 0;
-  }
-
-  @media (--min-large) {
-    margin-right: var(--spacing1x);
   }
 
   @media (--max-medium) {
@@ -49,6 +46,12 @@
 .seriesImageQuarters {
   @media (--min-large) {
     width: 25%;
+  }
+}
+
+.seriesImageMany {
+  @media (--min-large) {
+    width: calc(33.33% - var(--spacing1x));
   }
 }
 

--- a/web/src/pageTemplates/productsPage.js
+++ b/web/src/pageTemplates/productsPage.js
@@ -135,7 +135,8 @@ const ProductsPage = (props) => {
                     styles.seriesImages,
                     series.products.length > 2 ? styles.seriesImagesGrid : "",
                     series.products.length === 2 ? styles.seriesImagesTwo : "",
-                    series.products.length === 1 ? styles.seriesImagesOne : ""
+                    series.products.length === 1 ? styles.seriesImagesOne : "",
+                    series.products.length > 4 ? styles.seriesImagesMany : ""
                   )}
                 >
                   {series.products &&

--- a/web/src/pageTemplates/productsPage.module.scss
+++ b/web/src/pageTemplates/productsPage.module.scss
@@ -46,6 +46,11 @@
     flex-direction: column;
     row-gap: 0;
   }
+
+  @media (--min-large) {
+    column-gap: var(--spacing1x);
+    row-gap: var(--spacing1x);
+  }
 }
 
 .seriesImagesOne {
@@ -60,6 +65,12 @@
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     column-gap: var(--spacing1x);
+  }
+}
+
+.seriesImagesMany {
+  @media (--min-large) {
+    flex-wrap: wrap;
   }
 }
 


### PR DESCRIPTION
These will wrap and grow on each new line. They're slightly awkward when there are 7, 10, 13, etc., because they will stretch to full width on the last row. But I think this more elegant than having that last one hanging, and it's much simpler than trying to break the widths more complexly like I was hoping to do.

<img width="1242" alt="Screen Shot 2023-05-18 at 5 30 09 PM" src="https://github.com/singleportrait/blue-green-works/assets/1305667/9e2e9b21-1a5d-48e7-9082-d049eed1bdfa">
<img width="1113" alt="Screen Shot 2023-05-18 at 5 35 50 PM" src="https://github.com/singleportrait/blue-green-works/assets/1305667/2e04875a-f954-4ec9-ab6c-c5d5103081d3">
<img width="1134" alt="Screen Shot 2023-05-18 at 5 35 15 PM" src="https://github.com/singleportrait/blue-green-works/assets/1305667/47f12293-10f0-441d-aee4-84844adec134">
<img width="1103" alt="Screen Shot 2023-05-18 at 5 35 26 PM" src="https://github.com/singleportrait/blue-green-works/assets/1305667/26f66796-0c31-4888-8c4a-9c79c7317f6e">
<img width="1107" alt="Screen Shot 2023-05-18 at 5 35 33 PM" src="https://github.com/singleportrait/blue-green-works/assets/1305667/e9a0ab34-a056-439a-939f-7cd7410854c5">
